### PR TITLE
Fix default value for line in log entry

### DIFF
--- a/plugins/auth_ldap/init.php
+++ b/plugins/auth_ldap/init.php
@@ -78,7 +78,7 @@ class Auth_Ldap extends Plugin implements IAuthModule {
         $host->add_hook($host::HOOK_AUTH_USER, $this);
     }
 
-    private function _log($msg, $level = E_USER_NOTICE, $file = '', $line = '', $context = '') {
+    private function _log($msg, $level = E_USER_NOTICE, $file = '', $line = 0, $context = '') {
         $loggerFunction = Logger::get();
         if (is_object($loggerFunction)) {
             $loggerFunction->log_error($level, $msg, $file, $line, $context);


### PR DESCRIPTION
SQL schema requires the lineno to be a NOT NULL integer.

Without this fix, these errors get logged instead of the actual log messages:

```
Query INSERT INTO ttrss_error_log
				(errno, errstr, filename, lineno, context, owner_uid, created_at) VALUES
				(1024, 'User: XXXXXX authentication successful', '', '', '', NULL, NOW()) failed: ERROR:  invalid input syntax for integer: ""
LINE 3: ...24, 'User: XXXXXXXXX authentication successful', '', '', '', NU...
                                                             ^
classes/db/pgsql.php
```