### PR TITLE
Include login attribute in list of attributes to fetch

### DIFF
--- a/plugins/auth_ldap/init.php
+++ b/plugins/auth_ldap/init.php
@@ -331,7 +331,7 @@ class Auth_Ldap extends Plugin implements IAuthModule {
 
             //Searching for user
             $filterObj = str_replace('???', $this->ldap_escape($login), LDAP_AUTH_SEARCHFILTER);
-            $searchResults = @ldap_search($ldapConn, $this->_baseDN, $filterObj, array('displayName', 'title', 'sAMAccountName'), 0, 0, 0);
+            $searchResults = @ldap_search($ldapConn, $this->_baseDN, $filterObj, array('displayName', 'title', 'sAMAccountName', $this->_ldapLoginAttrib), 0, 0, 0);
             if ($searchResults === FALSE) {
                 $this->_log('LDAP Search Failed on base \'' . $this->_baseDN . '\' for \'' . $filterObj . '\'', E_USER_ERROR);
                 return FALSE;


### PR DESCRIPTION
We need to provide the login attribute in the list of attributes to fetch, otherwise (if you're not using displayName, title or sAMAccountName for example "uid") as the login attribute it fails later on with "Could not find user name attribute uid in LDAP entry".

To be honest I'm not sure if we need the rest of the list of attributes as I couldn't see when they would be used but wasn't going to delete them and break something unforseen.