### PR TITLE
this->_log: use a number as default

### DIFF
--- a/plugins/auth_ldap/init.php
+++ b/plugins/auth_ldap/init.php
@@ -78,7 +78,7 @@ class Auth_Ldap extends Plugin implements IAuthModule {
         $host->add_hook($host::HOOK_AUTH_USER, $this);
     }
 
-    private function _log($msg, $level = E_USER_NOTICE, $file = '', $line = '', $context = '') {
+    private function _log($msg, $level = E_USER_NOTICE, $file = '', $line = 0, $context = '') {
         $loggerFunction = Logger::get();
         if (is_object($loggerFunction)) {
             $loggerFunction->log_error($level, $msg, $file, $line, $context);


### PR DESCRIPTION
the sql logger of tinytinyrss does not allow strings for the line parameter. This was observed in tt-rss: df0115fc7a443669f3326f5abb49eb9754b59263