### PR TITLE
fix call to log method

### DIFF
--- a/plugins/auth_ldap/init.php
+++ b/plugins/auth_ldap/init.php
@@ -343,7 +343,7 @@ class Auth_Ldap extends Plugin implements IAuthModule {
                 $this->_log('Multiple DNs found for username ' . (string) $login, E_USER_WARNING);
                 return FALSE;
             } elseif ($count === 0) {
-                $this->_log((string) $login, 'Unknown User', E_USER_NOTICE);
+                $this->_log('Unknown User ' . (string) $login, E_USER_NOTICE);
                 return FALSE;
             }
 


### PR DESCRIPTION
I could not log in with the admin account anymore after activating the auth_ldap plugin. The reason was a PDOException that was thrown because of a method call with wrong argument types:

```
Uncaught PDOException: SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: 'Unknown User' for column `tiny_db`.`ttrss_error_log`.`errno` at row 1 in /usr/local/www/tt-rss/classes/logger/sql.php:37 

Stack trace: 
#0 /usr/local/www/tt-rss/classes/logger/sql.php(37): PDOStatement->execute(Array) 
#1 /usr/local/www/tt-rss/classes/logger.php(28): Logger_SQL->log_error('Unknown User', 'admin', 1024, 0, 'IP: 10.1.1.1 R...') 
#2 /usr/local/www/tt-rss/plugins/auth_ldap/init.php(84): Logger->log_error('Unknown User', 'admin', 1024, 0, '') 
#3 /usr/local/www/tt-rss/plugins/auth_ldap/init.php(346): Auth_Ldap->_log('admin', 'Unknown User', 1024) 
#4 /usr/local/www/tt-rss/include/functions.php(551): Auth_Ldap->authenticate('admin', 'SECRET', false) 
#5 /usr/local/www/tt-rss/classes/handler/public.php(660): authenticate_user('admin', 'SECRET') 
#6 /usr/local/www/tt-rss/public.php(35): Handler_Public->login() 
#7 {main} thrown
```

Obviously, some method arguments got mixed up. This commit fixes this.

Might be related to #31. 