### PR TITLE
Change to non-deprecated logging function

### DIFF
--- a/plugins/auth_ldap/init.php
+++ b/plugins/auth_ldap/init.php
@@ -79,12 +79,7 @@ class Auth_Ldap extends Plugin implements IAuthModule {
     }
 
     private function _log($msg, $level = E_USER_NOTICE, $file = '', $line = 0, $context = '') {
-        $loggerFunction = Logger::get();
-        if (is_object($loggerFunction)) {
-            $loggerFunction->log_error($level, $msg, $file, $line, $context);
-        } else {
-            trigger_error($msg, $level);
-        }
+        Logger::log_error($level, $msg, $file, $line, $context);
     }
 
     /**


### PR DESCRIPTION
Current use of `$loggerFunction = Logger::get();` is deprecated in recent versions of TTRSS. This PR applies the new method that replaced it as recommended by TTRSS themselves.